### PR TITLE
Replaced async delegate with async Task.

### DIFF
--- a/src/Loggr.Extensions.Logging/Loggr/LogClient.cs
+++ b/src/Loggr.Extensions.Logging/Loggr/LogClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Loggr
 {
@@ -141,8 +142,6 @@ namespace Loggr
 
         #region Post
 
-        private delegate void PostEventDelegate(Event eventObj);
-
         /// <summary>
         /// Posts the specified event to Loggr (posts asynchronously)
         /// </summary>
@@ -169,10 +168,14 @@ namespace Loggr
             // post async or sync
             if (async)
             {
-                PostEventDelegate del = new PostEventDelegate(PostEventBase);
-                del.BeginInvoke(eventObj, null, null);
+                PostEventBaseAsync(eventObj);
             }
             else PostEventBase(eventObj);
+        }
+
+        protected async void PostEventBaseAsync(Event eventObj)
+        {
+            await Task.Run(() => { PostEventBase(eventObj); });
         }
 
         [DebuggerNonUserCode()]


### PR DESCRIPTION
Async delegates are not supported in the .NET core runtime and throw an UnsupportedPlatform exception. My change simply uses an async method with a task, allowing this plugin to work properly with that runtime.